### PR TITLE
Fix --use-version flag for SNAPSHOT versions

### DIFF
--- a/paintera/__init__.py
+++ b/paintera/__init__.py
@@ -21,8 +21,13 @@ def _get_paintera_version(argv=None):
 
         def version_from_string(string):
             split = string.split('.')
-            major, minor, patch = [int(s) for s in split[:3]]
-            tag = '' if len(split) < 4 else split[3]
+            try:
+                major, minor, patch = [int(s) for s in split[:3]]
+                tag = None
+            except:
+                major, minor = [int(s) for s in split[:2]]
+                patch = int(split[2].split('-')[0])
+                tag = 'SNAPSHOT'
             return version._Version(major, minor, patch, tag)
 
         parser = argparse.ArgumentParser(usage=argparse.SUPPRESS)


### PR DESCRIPTION
Specifying a `SNAPSHOT` version would fail before.
With this patch, now supported:
 - `--use-version X.Y.Z`
 - `--use-version X.Y.Z-SNAPSHOT`
where `X`,`Y`,`Z` are integers.