### PR TITLE
Update main class

### DIFF
--- a/paintera/__init__.py
+++ b/paintera/__init__.py
@@ -12,7 +12,6 @@ _picocli_autocomplete    = 'picocli.AutoComplete'
 _paintera_cli_args       = 'org.janelia.saalfeldlab.paintera.PainteraCommandLineArgs'
 _groupId                 = 'org.janelia.saalfeldlab'
 _artifactId              = 'paintera'
-_slf4j_endpoint          = os.getenv('PAINTERA_SLF4J_BINDING', f'org.slf4j:slf4j-simple:{version._slf4j_version}')
 
 def _get_paintera_version(argv=None):
     import argparse
@@ -44,8 +43,7 @@ def launch_paintera():
         argv                        = argv,
         primary_endpoint            = f'{_groupId}:{_artifactId}',
         primary_endpoint_version    = paintera_version.maven_version(),
-        primary_endpoint_main_class = _paintera2,
-        secondary_endpoints         = (_slf4j_endpoint,))
+        primary_endpoint_main_class = _paintera2)
 
 def generate_paintera_bash_completion():
     relative_path = os.path.join(
@@ -96,6 +94,5 @@ def generate_paintera_bash_completion():
         primary_endpoint            = f'{_groupId}:{_artifactId}',
         argv                        = jgo_argv + argv,
         primary_endpoint_version    = version._paintera_version.maven_version(),
-        primary_endpoint_main_class = _picocli_autocomplete,
-        secondary_endpoints         = (_slf4j_endpoint,))
+        primary_endpoint_main_class = _picocli_autocomplete)
 

--- a/paintera/__init__.py
+++ b/paintera/__init__.py
@@ -6,7 +6,6 @@ import sys
 from . import version
 
 _paintera                = '@Paintera'
-_paintera2               = '@Paintera2'
 _paintera_show_container = '@PainteraShowContainer'
 _picocli_autocomplete    = 'picocli.AutoComplete'
 _paintera_cli_args       = 'org.janelia.saalfeldlab.paintera.PainteraCommandLineArgs'
@@ -43,7 +42,7 @@ def launch_paintera():
         argv                        = argv,
         primary_endpoint            = f'{_groupId}:{_artifactId}',
         primary_endpoint_version    = paintera_version.maven_version(),
-        primary_endpoint_main_class = _paintera2)
+        primary_endpoint_main_class = _paintera)
 
 def generate_paintera_bash_completion():
     relative_path = os.path.join(

--- a/paintera/version.py
+++ b/paintera/version.py
@@ -39,4 +39,3 @@ class _Version(object):
         return self.python_version()
 
 _paintera_version = _Version(0, 23, 4, 'dev0')
-_slf4j_version    = _Version(1, 7, 25, '')


### PR DESCRIPTION
Revert back to Paintera as main class instead of Paintera2

The old `Paintera` main class was removed and `Paintera2` was renamed to `Paintera` in saalfeldlab/paintera#390

This is based off of and should be merged after #3 rather than master to avoid conflicts.

cc @igorpisarev 